### PR TITLE
Set the large task queue to be the same as the normal task queue

### DIFF
--- a/helm-chart/banzai-floyds/templates/_helpers.tpl
+++ b/helm-chart/banzai-floyds/templates/_helpers.tpl
@@ -174,6 +174,8 @@ Celery task queue configuration
   value: {{ .Values.banzaiFloyds.queueName | quote }}
 - name: CELERY_TASK_QUEUE_NAME
   value: {{ .Values.banzaiFloyds.celeryTaskQueueName | quote }}
+- name: CELERY_LARGE_TASK_QUEUE_NAME
+  value: {{ .Values.banzaiFloyds.celeryTaskQueueName | quote }}
 - name: BANZAI_WORKER_LOGLEVEL
   value: {{ .Values.banzaiFloyds.banzaiWorkerLogLevel | quote }}
 - name: REFERENCE_CATALOG_URL


### PR DESCRIPTION
This is to prevent the listener from creating another queue to route messages to that will never be acked.