### PR TITLE
Simplified arc line centroiding.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.11.2 (2024-11-18)
+-------------------
+- Simplified the fitting for refining the peak centers. We no longer try to fit them all simultaneously
+- Updated the used the line list to remove a less isolated arc line
+
 0.11.1 (2024-11-12)
 -------------------
 - Fixes to the quality of the reductions

--- a/banzai_floyds/arc_lines.py
+++ b/banzai_floyds/arc_lines.py
@@ -57,12 +57,6 @@ used_lines = [
         'line_notes': ''
     },
     {
-        'wavelength': 7948.1764,
-        'line_strength': 0.272,
-        'line_source': 'ArI',
-        'line_notes': ''
-    },
-    {
         'wavelength': 8264.5225,
         'line_strength': 0.355,
         'line_source': 'ArI',
@@ -277,6 +271,11 @@ unused_lines = [{
     'line_strength': 0.3542,
     'line_source': 'ArI',
     'line_notes': 'Blend'
+}, {
+    'wavelength': 7948.1764,
+    'line_strength': 0.272,
+    'line_source': 'ArI',
+    'line_notes': ''
 }, {
     'wavelength': 8006.1567,
     'line_strength': 'nan',


### PR DESCRIPTION
I've simplified the peak refinement algorithm. Rather than trying to fit all lines simultaneously, we only fit one line at a time and only the data near the original peak. This has fixed some catastrophic failures that cause later stages to crash because the wavelength solution is no longer monotonic. 