### PR TITLE
Prefer same block/proposal for calibrations. Only use public calibrations. Use calibrations with the same slit width (i.e. same slit mask) for processing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,6 @@
 0.12.0 (2024-12-11)
 -------------------
-- We now prefer using calibrations, specifically arcs, from the same block or the same proposal
-- We only use public calibrations now
+- We now have prefer calibrations in the following order: same block, same proposal, any public calibration.
 - If a block is still going, we delay the processing in case there is a calibration taken at
   at the end of the block that we can use for processing
 - We now only use arcs and flats taken with the same slit width as the science data

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+0.12.0 (2024-12-11)
+-------------------
+- We now prefer using calibrations, specifically arcs, from the same block or the same proposal
+- We only use public calibrations now
+- If a block is still going, we delay the processing in case there is a calibration taken at
+  at the end of the block that we can use for processing
+- We now only use arcs and flats taken with the same slit width as the science data
+
 0.11.2 (2024-11-18)
 -------------------
 - Simplified the fitting for refining the peak centers. We no longer try to fit them all simultaneously

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lcogt/banzai:1.19.1
+FROM ghcr.io/lcogt/banzai:1.20.1
 
 USER root
 

--- a/banzai_floyds/frames.py
+++ b/banzai_floyds/frames.py
@@ -236,6 +236,10 @@ class FLOYDSObservationFrame(LCOObservationFrame):
     def elevation(self, value):
         self.meta['HEIGHT'] = value
 
+    @property
+    def slit_width(self):
+        return self.meta['APERWID']
+
 
 class FLOYDSCalibrationFrame(LCOCalibrationFrame, FLOYDSObservationFrame):
     def __init__(self, hdu_list: list, file_path: str, frame_id: int = None, grouping_criteria: list = None,

--- a/banzai_floyds/fringe.py
+++ b/banzai_floyds/fringe.py
@@ -112,6 +112,7 @@ class FringeCorrector(Stage):
         image.uncertainty[to_correct] /= fringe_correction[fringe_correction > 0.1]
         image.meta['L1FRNGOF'] = (fringe_offset, 'Fringe offset (pixels)')
         image.meta['L1STATFR'] = (1, 'Status flag for fringe frame correction')
+        image.public_date = datetime.now()
         return image
 
 

--- a/banzai_floyds/settings.py
+++ b/banzai_floyds/settings.py
@@ -52,3 +52,8 @@ CALIBRATION_FRAME_CLASS = 'banzai_floyds.frames.FLOYDSCalibrationFrame'
 CALIBRATION_IMAGE_TYPES = ['BIAS', 'DARK', 'SKYFLAT', 'BPM', 'LAMPFLAT', 'ARC', 'STANDARD']
 
 CALIBRATION_LOOKBACK = {'LAMPFLAT': 2.5}
+
+CALIBRATION_SET_CRITERIA = {'SKYFLAT': [], 'LAMPFLAT': ['slit_width'], 'ARC': ['slit_width'],
+                            'FRINGE': ['slit_width']}
+
+OBSTYPES_TO_DELAY = ['STANDARD', 'SPECTRUM']

--- a/helm-chart/banzai-floyds-e2e/templates/deployment.yaml
+++ b/helm-chart/banzai-floyds-e2e/templates/deployment.yaml
@@ -155,6 +155,9 @@ spec:
             - "--broker-url=localhost"
             - "--log-level=debug"
             - "--rlevel=91"
+            - "--prefer-same-block-cals"
+            - "--check-public-cals"
+            - "--prefer-same-proposal-cals"
           resources:
             requests:
               cpu: "0.1"

--- a/helm-chart/banzai-floyds/templates/cronjob.yaml
+++ b/helm-chart/banzai-floyds/templates/cronjob.yaml
@@ -38,5 +38,9 @@ spec:
             - "--rlevel=91"
             - "--db-address=$(DB_ADDRESS)"
             - "--no-file-cache"
+            - "--delay-to-block-end"
+            - "--same-block-cals"
+            - "--check-public-cals"
+            - "--prefer-same-proposal"
           restartPolicy: Never
 {{- end }}

--- a/helm-chart/banzai-floyds/templates/listener.yaml
+++ b/helm-chart/banzai-floyds/templates/listener.yaml
@@ -39,9 +39,9 @@ spec:
             - "--queue-name=$(QUEUE_NAME)"
             - "--no-file-cache"
             - "--delay-to-block-end"
-            - "--same-block-cals"
+            - "--prefer-same-block-cals"
             - "--check-public-cals"
-            - "--prefer-same-proposal"
+            - "--prefer-same-proposal-cals"
           env:
             {{- include "banzaiFloyds.Env" . | nindent 12}}
           resources:

--- a/helm-chart/banzai-floyds/templates/listener.yaml
+++ b/helm-chart/banzai-floyds/templates/listener.yaml
@@ -38,6 +38,10 @@ spec:
             - "--broker-url=$(FITS_BROKER)"
             - "--queue-name=$(QUEUE_NAME)"
             - "--no-file-cache"
+            - "--delay-to-block-end"
+            - "--same-block-cals"
+            - "--check-public-cals"
+            - "--prefer-same-proposal"
           env:
             {{- include "banzaiFloyds.Env" . | nindent 12}}
           resources:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ setup_requires =
     psycopg2-binary
 install_requires =
     astropy >= 4.3
-    banzai @ git+https://github.com/lcogt/banzai.git@cals-by-block.git
+    banzai @ git+https://github.com/lcogt/banzai.git@cals-by-block
     matplotlib
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ setup_requires =
     psycopg2-binary
 install_requires =
     astropy >= 4.3
-    banzai @ git+https://github.com/lcogt/banzai.git@cals-by-block
+    banzai @ git+https://github.com/lcogt/banzai.git@1.20.1
     matplotlib
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ setup_requires =
     psycopg2-binary
 install_requires =
     astropy >= 4.3
-    banzai @ git+https://github.com/lcogt/banzai.git@1.19.1
+    banzai @ git+https://github.com/lcogt/banzai.git@cals-by-block.git
     matplotlib
 
 [options.extras_require]


### PR DESCRIPTION
This PR pulls in the changes from lcogt/banzai#403 to prefer calibrations from the same block or the same proposal. We now also only use public arcs if there is not one in the same block/proposal. This also adds a delay to processing if the observing block is still in progress so that we can use the calibrations taken at the end of the block.

We also only use arcs and flats taken with the same slit width.