### PR TITLE
Updates to profile tracing that should be more robust for faint traces.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.19.0 (2025-08-15)
+-------------------
+- Updated how we trace the profile. We now stack the profile in a more robust way that should be less
+  sensitive to sky brightness
+
 0.18.0 (2025-07-14)
 -------------------
 - Updated the wavelength solution to make the 2d solution more stable. We now fit features row by row in a

--- a/banzai_floyds/profile.py
+++ b/banzai_floyds/profile.py
@@ -1,112 +1,16 @@
 import numpy as np
-from astropy.table import Table, vstack, join, Column
+from astropy.table import Table, vstack
 from numpy.polynomial.legendre import Legendre
-from banzai_floyds.matched_filter import matched_filter_metric, optimize_match_filter
+from banzai_floyds.matched_filter import matched_filter_metric
 from banzai_floyds.utils.fitting_utils import fwhm_to_sigma, gauss
 from banzai.stages import Stage
 from banzai.logs import get_logger
 from scipy.optimize import curve_fit
 
+from banzai_floyds.utils.fitting_utils import interp_with_errors
+
 
 logger = get_logger()
-
-
-def profile_sigma_model(params, x, center_polynomial, order, domain, bkg_order, bin_indexes):
-    wavelength_bin, y_order = x
-    center = center_polynomial(wavelength_bin)
-    sigma_polynomial = Legendre(params[:order + 1], domain=domain)
-    sigma = sigma_polynomial(wavelength_bin)
-    model = np.zeros(len(wavelength_bin))
-    for i, bin_index in enumerate(bin_indexes[:-1]):
-        start_ind = order + 1 + i * (bkg_order + 2)
-        bin_y_order = y_order[bin_index: bin_indexes[i + 1]]
-        model[bin_index: bin_indexes[i + 1]] += params[start_ind] * gauss(bin_y_order, center[bin_index],
-                                                                          sigma[bin_index])
-        background_polynomial = Legendre(params[start_ind + 1:start_ind + 1 + (i + 1) * (bkg_order + 2)],
-                                         domain=[np.min(bin_y_order), np.max(bin_y_order)])
-        model[bin_index: bin_indexes[i + 1]] += background_polynomial(bin_y_order)
-    return model
-
-
-def profile_fixed_center_model(x, *params):
-    # Assume a center of zero
-    sigma, amplitude, *background_coeffs = params
-    backgound_poly = Legendre(background_coeffs, domain=[np.min(x), np.max(x)])
-    return amplitude * gauss(x, 0, sigma) + backgound_poly(x)
-
-
-def interp_with_errors(x, y, yerr, x_new):
-    if np.min(x_new) < np.min(x) or np.max(x_new) > np.max(x):
-        raise ValueError('X for interpolation must be within the input range')
-    y_new = np.interp(x_new, x, y)
-
-    # This is a cute way to find the two bracketing indices for each new x value
-    left_indices = np.searchsorted(x, x_new, side='right') - 1
-
-    # Calculate the fractional distance between the bracketing x-values
-    # This is the term that shows up in the propogation of uncertatinty
-    alpha = (x_new - x[left_indices]) / (x[left_indices + 1] - x[left_indices])
-
-    yerr_new = np.sqrt((1 - alpha)**2 * yerr[left_indices]**2 + alpha**2 * yerr[left_indices + 1]**2)
-
-    return y_new, yerr_new
-
-
-def fit_profile_sigma(data, profile_centers, domains, poly_order=2, default_fwhm=6.0, bkg_order=3, step_size=25):
-    profile_sigmas = []
-    sigma_points = Table({'wavelength': [], 'sigma': [], 'sigma_error': [], 'order': []})
-    for order_id, center, domain in zip([1, 2], profile_centers, domains):
-        order_data = data[np.logical_and(data['order'] == order_id, data['order_wavelength_bin'] != 0)]
-        order_data = order_data.group_by('order_wavelength_bin')
-
-        # Group the data in bins of 25 columns (25 is big enough to increase the s/n by a factor of 5 but small enough
-        # to keep decent resolution for the fit accross the detector)
-        for left_index, right_index in zip(order_data.groups.indices[0:-step_size + 1:step_size],
-                                           order_data.groups.indices[step_size::step_size]):
-            data_to_fit = order_data[left_index: right_index]
-            data_to_fit.group_by('order_wavelength_bin')
-            # Grid the data onto a fixed set of y_order values (relative to the center of the trace)
-
-            # Grid the range +- 10 default sigma which should be enough to get to the background level, but
-            # small enough the background is still low order
-            # Prefer to not get within 5 pixels of either of the slit edges
-
-            y = data_to_fit['y_order'] - center(data_to_fit['order_wavelength_bin'])
-            grid_min = int(np.ceil(np.max([np.min(y) + 5, -10.0 * fwhm_to_sigma(default_fwhm)])))
-            grid_max = int(np.floor(np.min([np.max(y) - 5, 10.0 * fwhm_to_sigma(default_fwhm)])))
-            grid_interp = np.arange(grid_min, grid_max + 1)
-
-            profile, profile_errors = np.zeros(len(grid_interp)), np.zeros(len(grid_interp))
-            for data_bin in data_to_fit.groups:
-                y = data_bin['y_order'] - center(data_bin['order_wavelength_bin'])
-                bin_data, bin_errors = interp_with_errors(y, data_bin['data'], data_bin['uncertainty'], grid_interp)
-                profile += bin_data
-                profile_errors += bin_errors ** 2
-            profile_errors = np.sqrt(profile_errors)
-            initial_guess = np.zeros(2 + bkg_order + 1)
-            initial_guess[0] = fwhm_to_sigma(default_fwhm)
-            initial_guess[1] = profile[np.argmin(np.abs(grid_interp))] - np.median(profile)
-            initial_guess[2] = np.median(profile)
-            try:
-                best_fit, covariance = curve_fit(profile_fixed_center_model, grid_interp, profile, initial_guess,
-                                                 sigma=profile_errors)
-            except RuntimeError as e:
-                if 'Optimal parameters not found' in str(e):
-                    continue
-                else:
-                    raise
-            # Do a weighted sum of the wavelengths to get central wavelength
-            wavelength_point = np.sum(data_to_fit['wavelength'] * data_to_fit['uncertainty'] ** -2)
-            wavelength_point /= np.sum(data_to_fit['uncertainty'] ** -2)
-
-            sigma_row = Table({'wavelength': [wavelength_point],
-                               'sigma': [best_fit[0]],
-                               'order': [order_id],
-                               'sigma_error': [np.sqrt(covariance[0, 0])]})
-            sigma_points = vstack([sigma_points, sigma_row])
-        profile_sigmas.append(Legendre.fit(sigma_points['wavelength'], sigma_points['sigma'],
-                                           w=sigma_points['sigma_error'] ** -2, deg=poly_order, domain=domain))
-    return profile_sigmas, sigma_points
 
 
 def profile_gauss_fixed_width(params, x, sigma):
@@ -114,101 +18,105 @@ def profile_gauss_fixed_width(params, x, sigma):
     return gauss(x, center, sigma)
 
 
-def profile_fixed_width_full_order(params, x, sigma, y_order, domain):
-    polynomial = Legendre(params, domain=domain)
-    return gauss(y_order, polynomial(x), sigma)
+def profile_model(x, *params):
+    center, sigma, normalization = params
+    return normalization * gauss(x, center, sigma)
 
 
-def fit_profile_centers(data, domains, polynomial_order=7, profile_fwhm=6, step_size=25):
-    trace_points = Table({'wavelength': [], 'center': [], 'order': [], 'center_error': []})
+def fit_profile(data, domains, order_heights, center_polynomial_order=7, width_poly_order=2, step_size=25,
+                initial_fwhm=6.0):
+    trace_points = Table({'wavelength': [], 'center': [], 'order': [], 'center_error': [],
+                          'width': [], 'width_error': []})
     trace_centers = []
-    for order_id, domain in zip([1, 2], domains):
+    trace_sigmas = []
+    for order_id, domain, order_height in zip([1, 2], domains, order_heights):
         order_data = data[np.logical_and(data['order'] == order_id, data['order_wavelength_bin'] != 0)]
         order_data = order_data.group_by('order_wavelength_bin')
-        # Group the data in bins of 25 columns
-        for left_index, right_index in zip(order_data.groups.indices[0:-step_size + 1:step_size],
-                                           order_data.groups.indices[step_size::step_size]):
-            data_to_fit = order_data[left_index: right_index]
 
-            # Pass a match filter (with correct s/n scaling) with a gaussian with a default width
-            # Find a rough estimate of the center by running across the whole slit (excluding 1-sigma on each side)
-            sigma = fwhm_to_sigma(profile_fwhm)
-            # Remove the edges of the slit because they do funny things numerically
-            upper_bound = np.max(data_to_fit['y_order']) - sigma
-            lower_bound = np.min(data_to_fit['y_order']) + sigma
-            non_edge = np.logical_and(data_to_fit['y_order'] > lower_bound, data_to_fit['y_order'] < upper_bound)
+        # Group the data in bins of 25 columns (25 is big enough to increase the s/n by a factor of 5 but
+        # small enough that we don't expect the profile to have changed significantly)
+
+        # To combine wavelength bins, we interpolate onto a common grid with the order center in the middle
+        # Don't use the first or last set of 25 pixels as they may have order that falls off the chip
+        for left_index, right_index in zip(order_data.groups.indices[step_size:-2*step_size + 1:step_size],
+                                           order_data.groups.indices[2*step_size:-step_size:step_size]):
+            data_to_fit = order_data[left_index: right_index]
+            # Choose our grid to exclude 5 pixels at each edge
+            interp_y = np.arange(-(order_height // 2) + 5, (order_height // 2) + 1 - 5)
+            flux = np.zeros(len(interp_y))
+            flux_error = np.zeros(len(interp_y))
+            for bin in data_to_fit.group_by('order_wavelength_bin').groups:
+                this_flux, this_error = interp_with_errors(bin['y_order'], bin['data'], bin['uncertainty'], interp_y)
+                flux += this_flux
+                flux_error = np.sqrt(flux_error ** 2 + this_error ** 2)
+
+            # Do a quick removal of the background
+            flux -= np.median(flux)
+            if np.max(flux) / flux_error[np.argmax(flux)] < 5.0:
+                # If the s/n is too low, skip this bin
+                continue
+
+            sigma = fwhm_to_sigma(initial_fwhm)
             # Run a matched filter (don't fit yet) over all the centers
             snrs = []
-            centers = np.arange(int(np.min(data_to_fit['y_order'][non_edge])),
-                                int(np.max(data_to_fit['y_order'][non_edge])))
+            centers = np.arange(np.min(interp_y), np.max(interp_y) + 1)
             for center in centers:
-                metric = matched_filter_metric([center,],
-                                               data_to_fit['data'] - np.median(data_to_fit['data']),
-                                               data_to_fit['uncertainty'],
-                                               profile_gauss_fixed_width,
-                                               None,
-                                               None,
-                                               data_to_fit['y_order'], sigma)
+                metric = matched_filter_metric([center,], flux, flux_error, profile_gauss_fixed_width,
+                                               None, None, interp_y, sigma)
                 snrs.append(metric)
 
-            initial_guess = (centers[np.argmax(snrs)],)
+            initial_guess = (centers[np.argmax(snrs)], sigma, flux[np.argmax(snrs)])
+            close_to_center = np.abs(interp_y - initial_guess[0]) < 3.5 * initial_guess[1]
+            best_fit, covariance = curve_fit(profile_model, interp_y[close_to_center], flux[close_to_center],
+                                             initial_guess, sigma=flux_error[close_to_center])
 
-            (best_fit_center,), covariance = optimize_match_filter(
-                initial_guess,
-                data_to_fit['data'] - np.median(data_to_fit['data']),
-                data_to_fit['uncertainty'],
-                profile_gauss_fixed_width,
-                data_to_fit['y_order'],
-                args=(fwhm_to_sigma(profile_fwhm),),
-                bounds=[(lower_bound, upper_bound,),],
-                covariance=True,
-            )
             # Do an weighted sum that mirrors the fit to use for our wavelength
             wavelength_point = np.sum(data_to_fit['wavelength'] * data_to_fit['uncertainty'] ** -2)
             wavelength_point /= np.sum(data_to_fit['uncertainty'] ** -2)
             new_trace_table = Table({'wavelength': [wavelength_point],
-                                     'center': [best_fit_center],
+                                     'center': [best_fit[0]],
                                      'order': [order_id],
-                                     'center_error': [np.sqrt(covariance[0, 0])]})
+                                     'center_error': [np.sqrt(covariance[0, 0])],
+                                     'sigma': [best_fit[1]], 
+                                     'sigma_error': [np.sqrt(covariance[1, 1])]})
             trace_points = vstack([trace_points, new_trace_table])
         this_order = trace_points['order'] == order_id
-        initial_order_polynomial = Legendre.fit(trace_points['wavelength'][this_order],
-                                                trace_points['center'][this_order],
-                                                w=trace_points['center_error'][this_order] ** -2,
-                                                deg=polynomial_order, domain=domain)
+        if len(trace_points) > 0:
+            center_polynomial = Legendre.fit(trace_points['wavelength'][this_order],
+                                             trace_points['center'][this_order],
+                                             w=trace_points['center_error'][this_order] ** -2,
+                                             deg=center_polynomial_order, domain=domain)
+            sigma_polynomial = Legendre.fit(trace_points['wavelength'][this_order],
+                                            trace_points['sigma'][this_order],
+                                            w=trace_points['sigma_error'][this_order] ** -2,
+                                            deg=width_poly_order, domain=domain)
+        else:
+            center_polynomial = Legendre([0.0], domain=domain)
+            sigma_polynomial = Legendre([sigma], domain=domain)
 
-        # refine the fit using a continuous fit for the whole detector
-        simple_background = order_data['data'].groups.aggregate(np.median)
-        simple_background.name = 'background'
-        wavelength_column = Column(order_data['order_wavelength_bin'][order_data.groups.indices[:-1]],
-                                   name='order_wavelength_bin')
-        order_data = join(order_data, Table([simple_background, wavelength_column]), keys='order_wavelength_bin')
-        best_fit = optimize_match_filter(
-                initial_order_polynomial.coef,
-                order_data['data'] - order_data['background'],
-                order_data['uncertainty'],
-                profile_fixed_width_full_order,
-                order_data['wavelength'],
-                args=(fwhm_to_sigma(profile_fwhm), order_data['y_order'], domain),
-            )
-        trace_centers.append(Legendre(best_fit, domain=domain))
-    return trace_centers, trace_points
+        trace_centers.append(center_polynomial)
+        trace_sigmas.append(sigma_polynomial)
+    return trace_centers, trace_sigmas, trace_points
 
 
 class ProfileFitter(Stage):
-    POLYNOMIAL_ORDER = 7
+    CENTER_POLYNOMIAL_ORDER = 7
+    WIDTH_POLYNOMIAL_ORDER = 2
+    STEP_SIZE = 25
+    INITIAL_FWHM = 6.0
 
     def do_stage(self, image):
-        logger.info('Fitting profile centers', image=image)
-        # Note that the step_size parameters for both the center and sigma of the profile need to be
-        # the same for the tables to join nicely
-        profile_centers, center_points = fit_profile_centers(image.binned_data,
-                                                             image.wavelengths.wavelength_domains,
-                                                             polynomial_order=self.POLYNOMIAL_ORDER)
-        logger.info('Fitting profile widths', image=image)
-        profile_widths, profile_width_points = fit_profile_sigma(image.binned_data, profile_centers,
-                                                                 image.wavelengths.wavelength_domains)
-        fitted_points = join(center_points, profile_width_points, join_type='inner', keys=['wavelength', 'order'])
+        logger.info('Fitting profile centers and widths', image=image)
+        profile_centers, profile_sigmas, fitted_points = fit_profile(
+            image.binned_data,
+            image.wavelengths.wavelength_domains,
+            image.orders.order_heights,
+            center_polynomial_order=self.CENTER_POLYNOMIAL_ORDER,
+            step_size=self.STEP_SIZE,
+            width_poly_order=self.WIDTH_POLYNOMIAL_ORDER,
+            initial_fwhm=self.INITIAL_FWHM
+        )
+
         logger.info('Storing profile fits', image=image)
-        image.profile = profile_centers, profile_widths, fitted_points
+        image.profile = profile_centers, profile_sigmas, fitted_points
         return image

--- a/banzai_floyds/tests/test_profile.py
+++ b/banzai_floyds/tests/test_profile.py
@@ -1,7 +1,8 @@
-from banzai_floyds.profile import fit_profile_centers, fit_profile_sigma
+from banzai_floyds.profile import fit_profile
 from banzai_floyds.tests.utils import generate_fake_science_frame
 from banzai_floyds.utils.binning_utils import bin_data
 import numpy as np
+from banzai_floyds.utils.fitting_utils import sigma_to_fwhm
 
 
 def test_tracing():
@@ -11,19 +12,14 @@ def test_tracing():
     binned_data = bin_data(fake_frame.data, fake_frame.uncertainty, fake_frame.wavelengths,
                            fake_frame.orders)
     domains = [center.domain for center in fake_frame.input_profile_centers]
-    fitted_profile_centers, fitted_points = fit_profile_centers(binned_data, domains, profile_fwhm=4)
-    for fitted_center, input_center in zip(fitted_profile_centers, fake_frame.input_profile_centers):
+    fitted_profile_centers, fitted_profile_sigmas, fitted_points = fit_profile(
+        binned_data,
+        domains,
+        fake_frame.orders.order_heights,
+        initial_fwhm=sigma_to_fwhm(fake_frame.input_profile_sigma)
+    )
+    for fitted_center, fitted_sigma, input_center in zip(fitted_profile_centers, fitted_profile_sigmas,
+                                                         fake_frame.input_profile_centers):
         x = np.arange(fitted_center.domain[0], fitted_center.domain[1] + 1)
         np.testing.assert_allclose(fitted_center(x), input_center(x), atol=0.025, rtol=0.02)
-
-
-def test_profile_width_fitting():
-    np.random.seed(1242315)
-    fake_frame = generate_fake_science_frame(include_sky=True)
-    binned_data = bin_data(fake_frame.data, fake_frame.uncertainty, fake_frame.wavelengths,
-                           fake_frame.orders)
-    domains = [center.domain for center in fake_frame.input_profile_centers]
-    fitted_widths, fitted_points = fit_profile_sigma(binned_data, fake_frame.input_profile_centers, domains)
-    for fitted_width in fitted_widths:
-        x = np.arange(fitted_width.domain[0], fitted_width.domain[1] + 1)
-        np.testing.assert_allclose(fitted_width(x), fake_frame.input_profile_sigma, rtol=0.03)
+        np.testing.assert_allclose(fitted_sigma(x), fake_frame.input_profile_sigma, rtol=0.03)

--- a/banzai_floyds/utils/fitting_utils.py
+++ b/banzai_floyds/utils/fitting_utils.py
@@ -38,3 +38,20 @@ class Legendre2d:
         x_to_fit = mapdomain(x, self.domains[0], self.windows[0])
         y_to_fit = mapdomain(y, self.domains[1], self.windows[1])
         return legval(x_to_fit, self.x_coeffs) * legval(y_to_fit, self.y_coeffs)
+
+
+def interp_with_errors(x, y, yerr, x_new):
+    if np.min(x_new) < np.min(x) or np.max(x_new) > np.max(x):
+        raise ValueError('X for interpolation must be within the input range')
+    y_new = np.interp(x_new, x, y)
+
+    # This is a cute way to find the two bracketing indices for each new x value
+    left_indices = np.searchsorted(x, x_new, side='right') - 1
+
+    # Calculate the fractional distance between the bracketing x-values
+    # This is the term that shows up in the propogation of uncertatinty
+    alpha = (x_new - x[left_indices]) / (x[left_indices + 1] - x[left_indices])
+
+    yerr_new = np.sqrt((1 - alpha)**2 * yerr[left_indices]**2 + alpha**2 * yerr[left_indices + 1]**2)
+
+    return y_new, yerr_new

--- a/banzai_floyds/wavelengths.py
+++ b/banzai_floyds/wavelengths.py
@@ -371,7 +371,7 @@ class CalibrateWavelengths(Stage):
     # Tilts in degrees measured counterclockwise (right-handed coordinates)
     INITIAL_LINE_TILTS = {1: 8., 2: 8.}
     TILT_COEFF_ORDER = {'coj': 0, 'ogg': 0}
-    OFFSET_RANGES = {1: np.arange(7000.0, 7600.0, 0.5), 2: np.arange(4300, 5200, 0.5)}
+    OFFSET_RANGES = {1: np.arange(7000.0, 7900.0, 0.5), 2: np.arange(4300, 5200, 0.5)}
     # These thresholds were set using the data processed by the characterization tests.
     # The notebook is in the diagnostics folder
     MATCH_THRESHOLDS = {1: 50.0, 2: 25.0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "banzai-floyds"
-version = "0.18.0"
+version = "0.19.0"
 requires-python = ">=3.10,<4"
 description = "BANZAI Data Reduction for FLOYDS spectra"
 readme = "docs/README.rst"


### PR DESCRIPTION
I've updated the profile tracing algorithm to deal with faint traces better. We now take steps of 25 wavelength pixels, interpolate them onto a common grid, and fit a chi^2 model to get the width after using a match filter to get an initial guess for the centroid.

This should be roughly equivalent to what we did before, but this should do a better job at background removal. We also do not use the match filter to estimate the width as that has not proven to be stable. 

If no trace is detected, we set the profile to be the default width (fwhm = 6 pixels) at the center of the order. This should the background estimation be better behaved.