### PR TITLE
Background region test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.20.2 (2025-09-04)
+-------------------
+- Added an additional test to validate that we do indeed never use data off the chip for the background
+  and that we always have a minimum background region size of 5 pixels on each side of the trace
+
 0.20.1 (2025-08-26)
 -------------------
 - We now properly save the version of the banzai-floyds pipeline in the fits header rather than base banzai

--- a/banzai_floyds/background.py
+++ b/banzai_floyds/background.py
@@ -97,14 +97,14 @@ def set_background_region(image):
         # We choose a 2 pixel buffer at the edge of the order as a no fly zone
         # Note the minimum function here. This is different than min because it works elementwise
         lower_background_region = image.background_windows[order_id - 1][0]
-        lower_lim = data['y_order'] >= np.maximum(profile_center + lower_background_region[0] * data['profile_sigma'],
+        lower_lim = data['y_order'] > np.maximum(profile_center + lower_background_region[0] * data['profile_sigma'],
                                                   -(order_height // 2) + 2)
         # We require a minimum of 5 pixels in the background region on each side of the trace (+2 for the edge buffer)
         upper_lim = data['y_order'] <= np.maximum(profile_center + lower_background_region[1] * data['profile_sigma'],
                                                   -(order_height // 2) + 7)
         in_lower_region = np.logical_and(lower_lim, upper_lim)
         upper_background_region = image.background_windows[order_id - 1][1]
-        upper_lim = data['y_order'] <= np.minimum(profile_center + upper_background_region[1] * data['profile_sigma'],
+        upper_lim = data['y_order'] < np.minimum(profile_center + upper_background_region[1] * data['profile_sigma'],
                                                   order_height // 2 - 2)
         lower_lim = data['y_order'] >= np.minimum(profile_center + upper_background_region[0] * data['profile_sigma'],
                                                   order_height // 2 - 7)

--- a/banzai_floyds/background.py
+++ b/banzai_floyds/background.py
@@ -97,15 +97,16 @@ def set_background_region(image):
         # We choose a 2 pixel buffer at the edge of the order as a no fly zone
         # Note the minimum function here. This is different than min because it works elementwise
         lower_background_region = image.background_windows[order_id - 1][0]
-        lower_lim = data['y_order'] > np.maximum(profile_center + lower_background_region[0] * data['profile_sigma'],
-                                                  -(order_height // 2) + 2)
+        # Note the 3 here is because the comparison operator is >= and not just >
+        lower_lim = data['y_order'] >= np.maximum(profile_center + lower_background_region[0] * data['profile_sigma'],
+                                                  -(order_height // 2) + 3)
         # We require a minimum of 5 pixels in the background region on each side of the trace (+2 for the edge buffer)
         upper_lim = data['y_order'] <= np.maximum(profile_center + lower_background_region[1] * data['profile_sigma'],
                                                   -(order_height // 2) + 7)
         in_lower_region = np.logical_and(lower_lim, upper_lim)
         upper_background_region = image.background_windows[order_id - 1][1]
-        upper_lim = data['y_order'] < np.minimum(profile_center + upper_background_region[1] * data['profile_sigma'],
-                                                  order_height // 2 - 2)
+        upper_lim = data['y_order'] <= np.minimum(profile_center + upper_background_region[1] * data['profile_sigma'],
+                                                  order_height // 2 - 3)
         lower_lim = data['y_order'] >= np.minimum(profile_center + upper_background_region[0] * data['profile_sigma'],
                                                   order_height // 2 - 7)
         in_upper_region = np.logical_and(upper_lim, lower_lim)

--- a/banzai_floyds/fringe.py
+++ b/banzai_floyds/fringe.py
@@ -113,6 +113,8 @@ class FringeCorrector(Stage):
         logger.info('Correcting for fringing', image=image)
         x, y = np.meshgrid(np.arange(image.shape[1]), np.arange(image.shape[0]))
         in_order = image.orders.data == 1
+        # TODO: Should this be + or - in the offset. Feels like the difference between a passive and
+        # active transformation
         fringe_correction = fringe_spline(np.array([x[in_order], y[in_order] - fringe_offset]).T)
         to_correct = in_order.copy()
         to_correct[in_order] = fringe_correction > 0.1

--- a/characterization_testing/FringeFrameMaker.ipynb
+++ b/characterization_testing/FringeFrameMaker.ipynb
@@ -85,8 +85,16 @@
     "observations = {'request': {'configuration': {'LAMPFLAT': {'instrument_configs': {'exposure_count': 1}}}}}\n",
     "intruments = [banzai.dbs.get_instruments_at_site(site, context.db_address)[0] for site in ['ogg', 'coj']]\n",
     "for instrument in intruments:\n",
-    "    make_master_calibrations(instrument, 'LAMPFLAT', '2015-01-01', '2025-01-01', context)"
+    "    make_master_calibrations(instrument, 'LAMPFLAT', '2015-01-01', '2026-01-01', context)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2758593",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -2116,7 +2116,7 @@ test = ["pytest (>=7.4)", "pytest-cov (>=4.1)"]
 
 [[package]]
 name = "lco-banzai"
-version = "1.24.5"
+version = "1.24.6"
 description = "Python data reduction package for LCOGT data"
 optional = false
 python-versions = ">=3.10,<4"
@@ -2158,15 +2158,15 @@ torch = "*"
 [package.extras]
 cpu = ["torch"]
 cuda = ["torch"]
-docs = ["sphinx-astropy"]
+docs = ["ipykernel", "nbsphinx", "sphinx-astropy", "sphinx-autobuild", "sphinx-pyproject", "sphinx_rtd_theme"]
 style = ["pycodestyle"]
 test = ["coverage", "pytest (>=4.0)", "pytest-astropy"]
 
 [package.source]
 type = "git"
 url = "https://github.com/lcogt/banzai.git"
-reference = "1.24.5"
-resolved_reference = "b9dfd9497036f806e36270448c6389057b41d6c7"
+reference = "1.24.6"
+resolved_reference = "f988da1c9d6f0462cfd72c568981d955a2a6a7e4"
 
 [[package]]
 name = "lcogt-logging"
@@ -5718,4 +5718,4 @@ test = ["coverage", "mock", "pytest", "pytest-astropy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "16e134476845106dac4b0ffeb646d2568bd2df05e0dcec68df9ab70329a3776a"
+content-hash = "9f6ed470e1c1bbae7f89574837d76d8432e8ddb0f73f8be83f3c10e4d260b819"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "banzai-floyds"
-version = "0.20.1"
+version = "0.20.2"
 requires-python = ">=3.10,<4"
 description = "BANZAI Data Reduction for FLOYDS spectra"
 readme = "docs/README.rst"
@@ -19,7 +19,7 @@ urls = { "Documentation" = "https://banzai-floyds.readthedocs.io/", "Source" = "
 
 dependencies = [
     "astropy>=6.0",
-    "lco-banzai @ git+https://github.com/lcogt/banzai.git@1.24.5",
+    "lco-banzai @ git+https://github.com/lcogt/banzai.git@1.24.6",
     "matplotlib",
     "torch",
     "ipython"


### PR DESCRIPTION
Added a test to validate that we only choose data in order when the background regions are large and that we always have a minimum of 5 pixels per side of the trace and that we don't use the outermost 2 pixels of the order due to edge effects.