### PR TITLE
Made it easier to override background and extraction windows for re-extracting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.22.0 (2025-10-27)
+-------------------
+- Made it easier to override background and extraction windows for re-extracting
+
 0.21.0 (2025-10-07)
 -------------------
 - Added correct scaling to standard star files so that the output spectra are in ergs/s/cm^2/A

--- a/banzai_floyds/background.py
+++ b/banzai_floyds/background.py
@@ -84,9 +84,6 @@ def set_background_region(image):
     We no longer allow the background region to go to the edge of the order because weird things happen
     there. We also require at least 5 pixels on each side of the trace to be in the background region.
     """
-    if 'in_background' in image.binned_data.colnames:
-        return
-
     image.binned_data['in_background'] = False
     for order_id in [2, 1]:
         in_order = image.binned_data['order'] == order_id

--- a/banzai_floyds/extract.py
+++ b/banzai_floyds/extract.py
@@ -1,18 +1,11 @@
 from banzai.stages import Stage
 import numpy as np
 from astropy.table import Table
-from banzai.logs import get_logger
 from banzai_floyds.utils.binning_utils import rebin_data_combined
 from banzai_floyds.utils.flux_utils import flux_calibrate
 
 
-logger = get_logger()
-
-
 def set_extraction_region(image):
-    if 'extraction_window' in image.binned_data.colnames:
-        return
-
     image.binned_data['extraction_window'] = False
     for order_id in [2, 1]:
         in_order = image.binned_data['order'] == order_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "banzai-floyds"
-version = "0.21.0"
+version = "0.22.0"
 requires-python = ">=3.10,<4"
 description = "BANZAI Data Reduction for FLOYDS spectra"
 readme = "docs/README.rst"


### PR DESCRIPTION
When the UI is doing re-extracting, it sets the window values but starts the processing a partially processed file so that it doesn't have to refit the profile, etc. This means that the in_background values were already previously set from the initial extraction. The code I removed here was making it impossible to override those even if the background_windows values changed.