### PR TITLE
Remove match filter when detecting order locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Versions
 ========
 
+1.1.0 (2026-06-03)
+------------------
+
+- Removed match filter 2d fit step from locating the order positions due to instabilities
+
 1.0.2 (2026-03-30)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Versions
 1.1.0 (2026-06-03)
 ------------------
 
-- Removed match filter 2d fit step from locating the order positions due to instabilities
+- Removed matched-filter 2D fit step from locating the order positions due to instabilities
 
 1.0.2 (2026-03-30)
 ------------------

--- a/banzai_floyds/orders.py
+++ b/banzai_floyds/orders.py
@@ -188,9 +188,9 @@ def order_region(order_height, center, image_size):
     return order_mask
 
 
-def refine_peak_parabolic(metric, peak_indices):
+def refine_metric_peak_center(metric, peak_indices):
     """
-    Refine integer peak locations to sub-pixel precision with a 3-point parabolic interpolation.
+    Refine integer peak locations to sub-pixel precision with a parabolic interpolation.
 
     Parameters
     ----------
@@ -205,31 +205,21 @@ def refine_peak_parabolic(metric, peak_indices):
 
     Notes
     -----
-    Fitting a parabola to the metric value at the peak and its two neighbours moves the peak to the vertex,
-    which is exact for a locally quadratic metric. We fall back to the integer index whenever the parabola
-    is ill-conditioned: at the array edges (no neighbour), if a neighbour is not finite (e.g. a rejected
-    -inf row), if the curvature is not concave-down (not a real maximum), or if the implied shift exceeds
-    half a pixel (a 3-point fit can't justify moving the peak further than that).
+    We fall back to the integer index whenever at the edges.
     """
     refined = []
     n = len(metric)
     for i in peak_indices:
-        if i <= 0 or i >= n - 1:
-            refined.append(float(i))
+        # Fit a parabola to up to 3 points on either side, using whatever lands on the array and is finite
+        if i == 0 or i == n - 1:
+            refined.append(i)
             continue
-        y_minus, y_0, y_plus = metric[i - 1], metric[i], metric[i + 1]
-        if not (np.isfinite(y_minus) and np.isfinite(y_0) and np.isfinite(y_plus)):
-            refined.append(float(i))
-            continue
-        curvature = y_minus - 2.0 * y_0 + y_plus
-        # curvature < 0 for a concave-down maximum; anything else is not a peak we can refine
-        if curvature >= 0:
-            refined.append(float(i))
-            continue
-        offset = 0.5 * (y_minus - y_plus) / curvature
-        if np.abs(offset) > 0.5:
-            refined.append(float(i))
-            continue
+        low, high = max(i - 3, 0), min(i + 4, n)
+        x = np.arange(low, high) - i
+        metrics_to_fit = metric[low:high]
+        finite = np.isfinite(metrics_to_fit)
+        fit_metric = np.polyfit(x[finite], metrics_to_fit[finite], 2)
+        offset = -fit_metric[1] / (2 * fit_metric[0])
         refined.append(i + offset)
     return np.array(refined)
 
@@ -278,9 +268,9 @@ def estimate_order_centers(data, error, order_height, peak_separation=10, min_si
     matched_filtered = np.full(data.shape[0], -np.inf)
     for i in np.arange(data.shape[0]):
         # Run a matched filter using a top hat filter, dropping masked pixels from the region
-        filter_model = Legendre([i], domain=(0, data.shape[1] - 1))
+        filter_center = Legendre([i], domain=(0, data.shape[1] - 1))
 
-        filter_region = np.logical_and(order_region(order_height, filter_model, data.shape), good_pixels)
+        filter_region = np.logical_and(order_region(order_height, filter_center, data.shape), good_pixels)
         if filter_region.sum() < min_good_pixels:
             continue
         matched_filtered[i] = tophat_filter_metric(data, error, filter_region)
@@ -292,7 +282,7 @@ def estimate_order_centers(data, error, order_height, peak_separation=10, min_si
     # Why we have to use flatnonzero here instead of argwhere behaving the way I want is a mystery
     peak_indices = np.flatnonzero(peaks)
     # Refine the integer peaks to sub-pixel so the trace points are good enough to be the final order curve
-    return refine_peak_parabolic(matched_filtered, peak_indices)
+    return refine_metric_peak_center(matched_filtered, peak_indices)
 
 
 def trace_order(data, error, order_height, initial_center, initial_center_x,
@@ -333,53 +323,41 @@ def trace_order(data, error, order_height, initial_center, initial_center_x,
     centers = []
     xs = []
 
-    def find_center(x, previous_center):
-        # The previous center can be sub-pixel, so round it to place the integer search window. Clamp the
-        # window to the detector: without this, a center close to the bottom of the chip makes the slice
-        # start negative, which numpy silently wraps to the top of the array and produces a garbage center.
-        # We also use the clamped start when converting back to absolute coordinates.
-        previous_center = int(np.round(previous_center))
-        y_start = max(0, previous_center - search_height - order_height // 2)
-        y_stop = min(data.shape[0], previous_center + search_height + order_height // 2 + 1)
-        section = slice(y_start, y_stop, 1), slice(x - filter_width // 2, x + filter_width // 2 + 1, 1)
-        section_mask = None if mask is None else mask[section]
-        cut_center = estimate_order_centers(data[section], error[section], order_height, mask=section_mask)
-        # There wasn't a maximum here that was high enough s/n. Under this narrow search window there should
-        # otherwise be a single maximum, so we take it.
-        if len(cut_center) == 0:
-            return None
-        return cut_center[0] + y_start
-
-    # We can never trace within filter_width // 2 of the chip edge. Optionally tighten that to the order's
-    # valid x range so we don't step into columns where the order has fallen off or the other order dominates.
-    forward_stop = data.shape[1] - filter_width // 2
-    backward_stop = filter_width // 2
-    if x_max is not None:
-        forward_stop = min(forward_stop, int(np.floor(x_max)) + 1)
-    if x_min is not None:
-        backward_stop = max(backward_stop, int(np.ceil(x_min)) - 1)
-
+    if mask is None:
+        mask = np.zeros(data.shape, dtype=bool)
+    if x_min is None:
+        x_min = 0
+    if x_max is None:
+        x_max = data.shape[1]
+    # The matched filter needs filter_width // 2 columns on each side, so stay that far from the chip edge
+    x_min = int(max(x_min, filter_width // 2))
+    x_max = int(min(x_max, data.shape[1] - filter_width // 2))
+    # Start at the center where you know the approximate center
     # keep stepping until you reach the right edge of the trace region
-    for x in range(initial_center_x, forward_stop, step_size):
-        previous_center = initial_center if len(centers) == 0 else centers[-1]
-        center = find_center(x, previous_center)
-        if center is None:
-            continue
-        centers.append(center)
-        xs.append(x)
+    # walk right, then left
+    for steps in [(initial_center_x, x_max, step_size), (initial_center_x - step_size, x_min, -step_size)]:
+        previous_center = initial_center
 
-    # If we never found the order stepping to the right, there is no anchor to step left from.
-    if len(centers) == 0:
-        return np.array(xs), np.array(centers)
+        for x in range(*steps):
+            previous_center = int(np.round(previous_center))
+            # Clamp y_start so a low center can't make the slice start negative.
+            y_start = max(previous_center - order_height // 2 - search_height, 0)
+            section = (
+                slice(y_start, previous_center + order_height // 2 + 1 + search_height),
+                slice(x - filter_width // 2, x + filter_width // 2 + 1, 1)
+            )
+            center_estimates = estimate_order_centers(data[section], error[section], order_height, mask=mask[section])
+            if len(center_estimates) == 0:
+                continue
+            else:
+                this_center = center_estimates[0] + y_start
 
-    # Go back to the center and start stepping toward the left edge of the trace region
-    for x in range(initial_center_x - step_size, backward_stop, -step_size):
-        center = find_center(x, centers[0])
-        if center is None:
-            continue
-        centers.insert(0, center)
-        xs.insert(0, x)
-    return np.array(xs), np.array(centers)
+            centers.append(this_center)
+            xs.append(x)
+            previous_center = this_center
+
+    sorted_inds = np.argsort(xs)
+    return np.array(xs)[sorted_inds], np.array(centers)[sorted_inds]
 
 
 def fit_order_tweak(data, error, order_height, coeffs, x, domain):

--- a/banzai_floyds/orders.py
+++ b/banzai_floyds/orders.py
@@ -110,8 +110,13 @@ def tophat_filter_metric(data, error, region):
     -------
     float: Metric of the likelihood for the matched top-hat filter
     """
-    metric = (data[region] / error[region] / error[region]).sum()
-    metric /= ((1.0 / error[region] / error[region]).sum())**0.5
+    inverse_variance = 1.0 / error[region] / error[region]
+    normalization = inverse_variance.sum()
+    # If there are no (good) pixels in the region the metric is undefined; treat it as a non-detection.
+    if normalization <= 0:
+        return -np.inf
+    metric = (data[region] * inverse_variance).sum()
+    metric /= normalization ** 0.5
     return metric
 
 
@@ -188,7 +193,54 @@ def order_region(order_height, center, image_size):
     return order_mask
 
 
-def estimate_order_centers(data, error, order_height, peak_separation=10, min_signal_to_noise=200.0):
+def refine_peak_parabolic(metric, peak_indices):
+    """
+    Refine integer peak locations to sub-pixel precision with a 3-point parabolic interpolation.
+
+    Parameters
+    ----------
+    metric: array
+        The 1-d matched-filter metric the peaks were found in.
+    peak_indices: array of ints
+        Integer indices of the local maxima in metric.
+
+    Returns
+    -------
+    array of floats: sub-pixel peak locations
+
+    Notes
+    -----
+    Fitting a parabola to the metric value at the peak and its two neighbours moves the peak to the vertex,
+    which is exact for a locally quadratic metric. We fall back to the integer index whenever the parabola
+    is ill-conditioned: at the array edges (no neighbour), if a neighbour is not finite (e.g. a rejected
+    -inf row), if the curvature is not concave-down (not a real maximum), or if the implied shift exceeds
+    half a pixel (a 3-point fit can't justify moving the peak further than that).
+    """
+    refined = []
+    n = len(metric)
+    for i in peak_indices:
+        if i <= 0 or i >= n - 1:
+            refined.append(float(i))
+            continue
+        y_minus, y_0, y_plus = metric[i - 1], metric[i], metric[i + 1]
+        if not (np.isfinite(y_minus) and np.isfinite(y_0) and np.isfinite(y_plus)):
+            refined.append(float(i))
+            continue
+        curvature = y_minus - 2.0 * y_0 + y_plus
+        # curvature < 0 for a concave-down maximum; anything else is not a peak we can refine
+        if curvature >= 0:
+            refined.append(float(i))
+            continue
+        offset = 0.5 * (y_minus - y_plus) / curvature
+        if np.abs(offset) > 0.5:
+            refined.append(float(i))
+            continue
+        refined.append(i + offset)
+    return np.array(refined)
+
+
+def estimate_order_centers(data, error, order_height, peak_separation=10, min_signal_to_noise=200.0,
+                           mask=None, min_fraction=0.5):
     """
     Estimate the order centers by finding peaks using a simple cross correlation style sliding window metric
 
@@ -204,17 +256,38 @@ def estimate_order_centers(data, error, order_height, peak_separation=10, min_si
         Minimum distance between real peaks
     min_signal_to_noise: float
         Minimum value of the signal/noise metric to return in the list of peaks
+    mask: array, optional
+        Nonzero (or True) flags bad pixels to exclude from the matched filter. Same shape as data.
+        Masked pixels contribute nothing to the metric, which for a matched filter is equivalent to
+        shrinking the top-hat.
+    min_fraction: float
+        Minimum fraction of the nominal top-hat area that must be unmasked, on-chip pixels for a row to be
+        treated as a valid peak candidate. Because masking shrinks the filter (and therefore its
+        normalization), rows that are mostly off-chip or masked would otherwise produce metric values that
+        are not comparable to fully-sampled rows. Such rows are rejected rather than thresholded.
 
     Returns
     -------
-    array of ints with peaks of the matched filter metric
+    array of floats with the sub-pixel peaks of the matched filter metric
     """
-    matched_filtered = np.zeros(data.shape[0])
+    if mask is None:
+        good_pixels = np.ones(data.shape, dtype=bool)
+    else:
+        good_pixels = mask == 0
+    # Nominal number of pixels in a fully on-chip, fully unmasked top-hat. Rows that fall well short of this
+    # (chip edge, bad column, heavy masking) are not trustworthy detections.
+    full_area = order_height * data.shape[1]
+    min_good_pixels = min_fraction * full_area
+
+    # Rejected rows are left at -inf so they neither pass the threshold nor register as local maxima.
+    matched_filtered = np.full(data.shape[0], -np.inf)
     for i in np.arange(data.shape[0]):
-        # Run a matched filter using a top hat filter
+        # Run a matched filter using a top hat filter, dropping masked pixels from the region
         filter_model = Legendre([i], domain=(0, data.shape[1] - 1))
 
-        filter_region = order_region(order_height, filter_model, data.shape)
+        filter_region = np.logical_and(order_region(order_height, filter_model, data.shape), good_pixels)
+        if filter_region.sum() < min_good_pixels:
+            continue
         matched_filtered[i] = tophat_filter_metric(data, error, filter_region)
     peaks = matched_filtered == maximum_filter1d(matched_filtered,
                                                  size=peak_separation,
@@ -222,11 +295,14 @@ def estimate_order_centers(data, error, order_height, peak_separation=10, min_si
                                                  cval=0.0)
     peaks = np.logical_and(peaks, matched_filtered > min_signal_to_noise)
     # Why we have to use flatnonzero here instead of argwhere behaving the way I want is a mystery
-    return np.flatnonzero(peaks)
+    peak_indices = np.flatnonzero(peaks)
+    # Refine the integer peaks to sub-pixel so the trace points are good enough to be the final order curve
+    return refine_peak_parabolic(matched_filtered, peak_indices)
 
 
 def trace_order(data, error, order_height, initial_center, initial_center_x,
-                step_size=11, filter_width=21, search_height=7):
+                step_size=11, filter_width=21, search_height=7, mask=None,
+                x_min=None, x_max=None):
     """
     Trace an order by stepping a window function along from the center of the chip
 
@@ -247,6 +323,13 @@ def trace_order(data, error, order_height, initial_center, initial_center_x,
         x-width of the filter to sum to search for peaks in the metric
     search_height: int
         Number of pixels to search above and below the previous best center
+    mask: array, optional
+        Nonzero (or True) flags bad pixels to exclude from the matched filter. Same shape as data.
+        Excluding bad columns and cosmics here keeps them from seeding the trace with a false center.
+    x_min, x_max: float, optional
+        Restrict the trace to columns within [x_min, x_max], the order's valid x range. Outside this range
+        the order falls off the chip or is dominated by the adjacent order, which is where the sequential
+        trace is most likely to wander. The chip-edge margin of filter_width // 2 is always applied too.
 
     Returns
     -------
@@ -254,77 +337,54 @@ def trace_order(data, error, order_height, initial_center, initial_center_x,
     """
     centers = []
     xs = []
-    # keep stepping until you get to the edge of the chip
-    for x in range(initial_center_x, data.shape[1] - filter_width // 2,
-                   step_size):
-        if len(centers) == 0:
-            previous_center = initial_center
-        else:
-            previous_center = centers[-1]
-        x_section = slice(x - filter_width // 2, x + filter_width // 2 + 1, 1)
-        y_section = slice(previous_center - search_height - order_height // 2,
-                          previous_center + search_height + order_height // 2 + 1,
-                          1)
-        section = y_section, x_section
 
-        cut_center = estimate_order_centers(data[section], error[section],
-                                            order_height)
+    def find_center(x, previous_center):
+        # The previous center can be sub-pixel, so round it to place the integer search window. Clamp the
+        # window to the detector: without this, a center close to the bottom of the chip makes the slice
+        # start negative, which numpy silently wraps to the top of the array and produces a garbage center.
+        # We also use the clamped start when converting back to absolute coordinates.
+        previous_center = int(np.round(previous_center))
+        y_start = max(0, previous_center - search_height - order_height // 2)
+        y_stop = min(data.shape[0], previous_center + search_height + order_height // 2 + 1)
+        section = slice(y_start, y_stop, 1), slice(x - filter_width // 2, x + filter_width // 2 + 1, 1)
+        section_mask = None if mask is None else mask[section]
+        cut_center = estimate_order_centers(data[section], error[section], order_height, mask=section_mask)
+        # There wasn't a maximum here that was high enough s/n. Under this narrow search window there should
+        # otherwise be a single maximum, so we take it.
         if len(cut_center) == 0:
+            return None
+        return cut_center[0] + y_start
+
+    # We can never trace within filter_width // 2 of the chip edge. Optionally tighten that to the order's
+    # valid x range so we don't step into columns where the order has fallen off or the other order dominates.
+    forward_stop = data.shape[1] - filter_width // 2
+    backward_stop = filter_width // 2
+    if x_max is not None:
+        forward_stop = min(forward_stop, int(np.floor(x_max)) + 1)
+    if x_min is not None:
+        backward_stop = max(backward_stop, int(np.ceil(x_min)) - 1)
+
+    # keep stepping until you reach the right edge of the trace region
+    for x in range(initial_center_x, forward_stop, step_size):
+        previous_center = initial_center if len(centers) == 0 else centers[-1]
+        center = find_center(x, previous_center)
+        if center is None:
             continue
-        else:
-            cut_center = cut_center[0]
-        centers.append(cut_center + previous_center - search_height -
-                       order_height // 2)
+        centers.append(center)
         xs.append(x)
 
-    # Go back to the center and start stepping the opposite direction
-    for x in range(initial_center_x - step_size, filter_width // 2,
-                   -step_size):
-        previous_center = centers[0]
-        y_section = slice(
-            previous_center - search_height - order_height // 2,
-            previous_center + search_height + order_height // 2 + 1, 1)
-        x_section = slice(x - filter_width // 2, x + filter_width // 2 + 1, 1)
-        section = y_section, x_section
-        cut_center = estimate_order_centers(data[section], error[section],
-                                            order_height)
-        if len(cut_center) == 0:
+    # If we never found the order stepping to the right, there is no anchor to step left from.
+    if len(centers) == 0:
+        return np.array(xs), np.array(centers)
+
+    # Go back to the center and start stepping toward the left edge of the trace region
+    for x in range(initial_center_x - step_size, backward_stop, -step_size):
+        center = find_center(x, centers[0])
+        if center is None:
             continue
-        else:
-            cut_center = cut_center[0]
-        centers.insert(0, cut_center + previous_center - search_height - order_height // 2)
+        centers.insert(0, center)
         xs.insert(0, x)
     return np.array(xs), np.array(centers)
-
-
-def fit_order_curve(data, error, order_height, initial_coeffs, x, domain):
-    """
-    Maximize the matched filter metric to find the best fit order curvature and location
-
-    Parameters
-    ----------
-    data: array to fit order
-    error: array of uncertainties
-        Same shapes as the input data array
-    order_height: int
-        Number of pixels in the top of the hat
-    initial_coeffs: array
-        Initial guesses for the Legendre polynomial coefficients of the center of the order
-    x: tuple of arrays independent coordinates x, y
-        Arrays should be the same shape as the input data
-    domain: length 2 tuple of floats
-        Domain to be used for the polynomial see numpy.polynomial.legendre.Legendre
-
-    Returns
-    -------
-    Polynomial model function of the best fit
-    """
-
-    # For this to work efficiently, you probably need a good initial guess. If we have that, we should define
-    # a window of pixels around the initial guess to do the fit to optimize not fitting a bunch of zeros
-    best_fit_coeffs = optimize_match_filter(initial_coeffs, data, error, smooth_order_weights,
-                                            x, args=(order_height, domain,))
-    return Legendre(best_fit_coeffs, domain=domain)
 
 
 def fit_order_tweak(data, error, order_height, coeffs, x, domain):
@@ -422,20 +482,26 @@ class OrderSolver(Stage):
             center_section = slice(None), slice(image.data.shape[1] // 2 - self.CENTER_CUT_WIDTH // 2,
                                                 image.data.shape[1] // 2 + self.CENTER_CUT_WIDTH // 2 + 1, 1)
             order_centers = estimate_order_centers(image.data[center_section], image.uncertainty[center_section],
-                                                   order_height=order_height)
+                                                   order_height=order_height, mask=image.mask[center_section])
             order_estimates = []
             for i, order_center in enumerate(order_centers):
+                # The valid x range for this order; use it to bound the trace so we don't wander into
+                # columns where the order has fallen off the chip or the other order dominates.
+                order_region = get_order_location(image.dateobs, i + 1, image.instrument,
+                                                  self.runtime_context.db_address)
+                # Start the trace at the chip center, clamped into the order's x range so the seed column
+                # is always somewhere the order actually exists.
+                start_x = int(np.clip(image.data.shape[1] // 2, order_region[0], order_region[1]))
                 x, order_locations = trace_order(image.data, image.uncertainty,
                                                  order_height,
                                                  order_center,
-                                                 image.data.shape[1] // 2)
-                order_region = get_order_location(image.dateobs, i + 1, image.instrument,
-                                                  self.runtime_context.db_address)
-                good_region = np.logical_and(x >= order_region[0],
-                                             x <= order_region[1])
+                                                 start_x,
+                                                 mask=image.mask,
+                                                 x_min=order_region[0],
+                                                 x_max=order_region[1])
                 initial_model = Legendre.fit(deg=self.POLYNOMIAL_ORDER,
-                                             x=x[good_region],
-                                             y=order_locations[good_region],
+                                             x=x,
+                                             y=order_locations,
                                              domain=(order_region[0],
                                                      order_region[1]))
                 order_estimates.append((initial_model.coef, order_height, initial_model.domain))
@@ -444,18 +510,12 @@ class OrderSolver(Stage):
             order_estimates = [(coeff, height, domain)
                                for coeff, height, domain in
                                zip(image.orders.coeffs, image.orders.order_heights, image.orders.domains)]
-        # Do a fit to get the curvature of the slit
-        order_curves = []
-        for i, (coeff, height, domain) in enumerate(order_estimates):
-            x2d, y2d = np.meshgrid(np.arange(image.shape[1]), np.arange(image.shape[0]))
-            region = np.logical_and(x2d <= domain[1], x2d >= domain[0])
-            center_model = Legendre(coeff, domain=domain)
-            # Only keep pixels +- half the height above the initial guess
-            region = np.logical_and(region, np.abs(y2d - center_model(x2d)) <= height)
-            order_curve = fit_order_curve(image.data[region], image.uncertainty[region],
-                                          height, coeff, (x2d[region], y2d[region]), domain)
-            order_curves.append(order_curve)
-        order_heights = [height for _ in order_estimates]
+        # The sub-pixel trace points already pin down the curvature of the slit, so the polynomial fit to
+        # those points (built above) is our order curve. We no longer run a full 2-d matched-filter
+        # parameter estimation on top of it: it was sensitive to its initial guess and prone to settling
+        # in local optima, and the trace fit recovers the same curve more robustly.
+        order_curves = [Legendre(coeff, domain=domain) for coeff, _, domain in order_estimates]
+        order_heights = [height for _, height, _ in order_estimates]
         image.orders = Orders(order_curves, image.data.shape, order_heights)
         image.add_or_update(ArrayData(image.orders.data, name='ORDERS'))
         coeff_table = [{f'c{i}': coeff for i, coeff in enumerate(coeffs)}

--- a/banzai_floyds/orders.py
+++ b/banzai_floyds/orders.py
@@ -110,13 +110,8 @@ def tophat_filter_metric(data, error, region):
     -------
     float: Metric of the likelihood for the matched top-hat filter
     """
-    inverse_variance = 1.0 / error[region] / error[region]
-    normalization = inverse_variance.sum()
-    # If there are no (good) pixels in the region the metric is undefined; treat it as a non-detection.
-    if normalization <= 0:
-        return -np.inf
-    metric = (data[region] * inverse_variance).sum()
-    metric /= normalization ** 0.5
+    metric = (data[region] / error[region] / error[region]).sum()
+    metric /= ((1.0 / error[region] / error[region]).sum())**0.5
     return metric
 
 
@@ -483,19 +478,17 @@ class OrderSolver(Stage):
                                                 image.data.shape[1] // 2 + self.CENTER_CUT_WIDTH // 2 + 1, 1)
             order_centers = estimate_order_centers(image.data[center_section], image.uncertainty[center_section],
                                                    order_height=order_height, mask=image.mask[center_section])
-            order_estimates = []
+            order_curves = []
+            order_heights = []
             for i, order_center in enumerate(order_centers):
-                # The valid x range for this order; use it to bound the trace so we don't wander into
-                # columns where the order has fallen off the chip or the other order dominates.
+                # Get the x domain where the order is defined so we don't hit weird edge effects
                 order_region = get_order_location(image.dateobs, i + 1, image.instrument,
                                                   self.runtime_context.db_address)
-                # Start the trace at the chip center, clamped into the order's x range so the seed column
-                # is always somewhere the order actually exists.
-                start_x = int(np.clip(image.data.shape[1] // 2, order_region[0], order_region[1]))
+                # Start the trace at the chip center
                 x, order_locations = trace_order(image.data, image.uncertainty,
                                                  order_height,
                                                  order_center,
-                                                 start_x,
+                                                 image.data.shape[1] // 2,
                                                  mask=image.mask,
                                                  x_min=order_region[0],
                                                  x_max=order_region[1])
@@ -504,18 +497,14 @@ class OrderSolver(Stage):
                                              y=order_locations,
                                              domain=(order_region[0],
                                                      order_region[1]))
-                order_estimates.append((initial_model.coef, order_height, initial_model.domain))
+                order_curves.append(initial_model)
+                order_heights.append(order_height)
         else:
             # Load from previous solve
-            order_estimates = [(coeff, height, domain)
-                               for coeff, height, domain in
-                               zip(image.orders.coeffs, image.orders.order_heights, image.orders.domains)]
-        # The sub-pixel trace points already pin down the curvature of the slit, so the polynomial fit to
-        # those points (built above) is our order curve. We no longer run a full 2-d matched-filter
-        # parameter estimation on top of it: it was sensitive to its initial guess and prone to settling
-        # in local optima, and the trace fit recovers the same curve more robustly.
-        order_curves = [Legendre(coeff, domain=domain) for coeff, _, domain in order_estimates]
-        order_heights = [height for _, height, _ in order_estimates]
+            order_curves = [Legendre(coeff, domain=domain)
+                            for coeff, domain in zip(image.orders.coeffs, image.orders.domains)]
+            order_heights = [height for height in image.orders.order_heights]
+
         image.orders = Orders(order_curves, image.data.shape, order_heights)
         image.add_or_update(ArrayData(image.orders.data, name='ORDERS'))
         coeff_table = [{f'c{i}': coeff for i, coeff in enumerate(coeffs)}

--- a/banzai_floyds/orders.py
+++ b/banzai_floyds/orders.py
@@ -218,6 +218,9 @@ def refine_metric_peak_center(metric, peak_indices):
         x = np.arange(low, high) - i
         metrics_to_fit = metric[low:high]
         finite = np.isfinite(metrics_to_fit)
+        if np.sum(finite) < 3:
+            refined.append(i)
+            continue
         fit_metric = np.polyfit(x[finite], metrics_to_fit[finite], 2)
         offset = -fit_metric[1] / (2 * fit_metric[0])
         refined.append(i + offset)
@@ -332,9 +335,8 @@ def trace_order(data, error, order_height, initial_center, initial_center_x,
     # The matched filter needs filter_width // 2 columns on each side, so stay that far from the chip edge
     x_min = int(max(x_min, filter_width // 2))
     x_max = int(min(x_max, data.shape[1] - filter_width // 2))
-    # Start at the center where you know the approximate center
-    # keep stepping until you reach the right edge of the trace region
-    # walk right, then left
+    # Start tracing at the center of the order, step right until you get to the end. Then starting from the 
+    # center again, step left until you get to the end.
     for steps in [(initial_center_x, x_max, step_size), (initial_center_x - step_size, x_min, -step_size)]:
         previous_center = initial_center
 
@@ -350,7 +352,9 @@ def trace_order(data, error, order_height, initial_center, initial_center_x,
             if len(center_estimates) == 0:
                 continue
             else:
-                this_center = center_estimates[0] + y_start
+                # Pull the center_estimate closest to the previous center to make sure we don't wander
+                center_estimates += y_start
+                this_center = center_estimates[np.argmin(np.abs(center_estimates - previous_center))]
 
             centers.append(this_center)
             xs.append(x)

--- a/banzai_floyds/tests/test_orders.py
+++ b/banzai_floyds/tests/test_orders.py
@@ -24,7 +24,6 @@ def test_blind_center_search():
         error[order_slice] = 100.0
 
     found_centers = estimate_order_centers(data, error, order_height)
-    # Centers are now sub-pixel, so check proximity rather than exact integer membership
     for i in order_centers:
         assert np.min(np.abs(found_centers - i)) < 0.5
 

--- a/banzai_floyds/tests/test_orders.py
+++ b/banzai_floyds/tests/test_orders.py
@@ -1,4 +1,4 @@
-from banzai_floyds.orders import estimate_order_centers, order_region, fit_order_curve, OrderSolver, trace_order
+from banzai_floyds.orders import estimate_order_centers, order_region, OrderSolver, trace_order
 from banzai_floyds.orders import OrderTweaker, Orders
 import numpy as np
 from numpy.polynomial.legendre import Legendre
@@ -24,8 +24,9 @@ def test_blind_center_search():
         error[order_slice] = 100.0
 
     found_centers = estimate_order_centers(data, error, order_height)
+    # Centers are now sub-pixel, so check proximity rather than exact integer membership
     for i in order_centers:
-        assert i in found_centers
+        assert np.min(np.abs(found_centers - i)) < 0.5
 
 
 def test_order_region():
@@ -34,24 +35,6 @@ def test_order_region():
     expected = np.zeros((ny, nx), dtype=np.uint8)
     expected[25:-25, :501] = 1
     np.testing.assert_allclose(orders.data, expected)
-
-
-def test_fit_orders():
-    data = np.zeros((512, 501))
-    error = np.ones((512, 501))
-    order_center = 151
-    input_center_params = [order_center, 10, 20]
-    order_height = 85
-    input_order_region = order_region(order_height, Legendre(input_center_params, domain=(0, data.shape[1] - 1)),
-                                      data.shape)
-    data[input_order_region] = 1000.0
-    error[input_order_region] = 100.0
-    x2d, y2d = np.meshgrid(np.arange(data.shape[1]), np.arange(data.shape[0]))
-    # Give an initial guess of the center, but zero curvature to make sure we converge
-    fitted_order_model = fit_order_curve(data, error, order_height, [order_center, 5, 15],
-                                         (x2d, y2d), (np.min(x2d), np.max(x2d)))
-    fitted_order_region = order_region(order_height, fitted_order_model, data.shape)
-    assert (input_order_region != fitted_order_region).sum() < 150
 
 
 @mock.patch('banzai_floyds.orders.dbs.get_order_height')

--- a/characterization_testing/WavelengthCalibration.ipynb
+++ b/characterization_testing/WavelengthCalibration.ipynb
@@ -418,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "banzai-floyds"
-version = "1.0.2"
+version = "1.1.0"
 requires-python = ">=3.11,<4"
 description = "BANZAI Data Reduction for FLOYDS spectra"
 readme = "docs/README.rst"

--- a/uv.lock
+++ b/uv.lock
@@ -149,7 +149,7 @@ wheels = [
 
 [[package]]
 name = "banzai-floyds"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR removes the 2-d matched filter fit from detecting orders. Instead, we use the matched filter metric to just find the location is 1-d and step through. Then we fit polynomial to the 1d points. Adding the curvature in the 2d matched filter metric appeared to be less numerically stable, even when we gave it basically the right answer. We also remove masked pixels from the fit now so hopefully cosmic rays are less likely to affect an individual measurement of the order center as we step through wavelengths.

<img width="1321" height="571" alt="ds9" src="https://github.com/user-attachments/assets/ff949771-c869-4fbe-9af8-5d1e2d25bd5e" />
