### PR TITLE
Improve fringe correction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Versions
 - Removed matched-filter 2D fit step from locating the order positions due to instabilities
 - Significant updates to the wavelength solution, removing the 2-d match filter approach to
   increase the robustness of the fit.
+- Fix a filenaming bug for the stacked fringe frames
+  where all files on the same day would have the same name
+  irrespective of slit width.
+
 
 1.0.2 (2026-03-30)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,6 @@ Versions
   where all files on the same day would have the same name
   irrespective of slit width.
 
-
 1.0.2 (2026-03-30)
 ------------------
 

--- a/banzai_floyds/settings.py
+++ b/banzai_floyds/settings.py
@@ -43,7 +43,11 @@ LAST_STAGE = {
 
 CALIBRATION_STACKER_STAGES = {'LAMPFLAT': ['banzai_floyds.fringe.FringeMaker']}
 CALIBRATION_MIN_FRAMES['LAMPFLAT'] = 2  # noqa: F405
-CALIBRATION_FILENAME_FUNCTIONS['LAMPFLAT'] = ('banzai_floyds.utils.file_utils.config_to_filename',)  # noqa: F405
+
+CALIBRATION_FILENAME_FUNCTIONS['LAMPFLAT'] = (  # noqa: F405
+    'banzai_floyds.utils.file_utils.lampflat_config_to_filename',
+    'banzai_floyds.utils.file_utils.slit_width_to_filename'
+)
 
 EXTRA_STAGES = {'SPECTRUM': None, 'LAMPFLAT': ['banzai_floyds.fringe.FringeContinuumFitter'],
                 'STANDARD': None,
@@ -58,8 +62,7 @@ CALIBRATION_IMAGE_TYPES = ['BIAS', 'DARK', 'SKYFLAT', 'BPM', 'LAMPFLAT', 'ARC', 
 
 CALIBRATION_LOOKBACK = {'LAMPFLAT': 2.5}
 
-CALIBRATION_SET_CRITERIA = {'SKYFLAT': ['slit_width'], 'LAMPFLAT': ['slit_width'], 'ARC': ['slit_width'],
-                            'FRINGE': ['slit_width']}
+CALIBRATION_SET_CRITERIA = {'SKYFLAT': ['slit_width'], 'LAMPFLAT': ['slit_width'], 'ARC': ['slit_width']}
 
 OBSTYPES_TO_DELAY = ['STANDARD', 'SPECTRUM']
 

--- a/banzai_floyds/tests/test_fringing.py
+++ b/banzai_floyds/tests/test_fringing.py
@@ -54,7 +54,8 @@ def test_create_super_fringe():
     input_context = context.Context({
         'CALIBRATION_MIN_FRAMES': {'LAMPFLAT': 2},
         'TELESCOPE_FILENAME_FUNCTION': 'banzai.utils.file_utils.telescope_to_filename',
-        'CALIBRATION_FILENAME_FUNCTIONS': {'LAMPFLAT': ()},
+        'CALIBRATION_FILENAME_FUNCTIONS': {'LAMPFLAT': ('banzai_floyds.utils.file_utils.lampflat_config_to_filename',
+                                                        'banzai_floyds.utils.file_utils.slit_width_to_filename')},
         'CALIBRATION_SET_CRITERIA': {'LAMPFLAT': []},
         'CALIBRATION_FRAME_CLASS': 'banzai_floyds.frames.FLOYDSCalibrationFrame',
         'MASTER_CALIBRATION_EXTENSION_ORDER': {'LAMPFLAT': ['SPECTRUM', 'FRINGE']},
@@ -63,6 +64,9 @@ def test_create_super_fringe():
     })
     stage = FringeMaker(input_context)
     frame = stage.do_stage(frames)
+
+    # Added a quick test to make sure the slit width correctly makes it into the filename.
+    assert '2.0as' in frame.filename
     # Assert that the super fringe matches the input
     # Trim off the edges of the order due to edge effects
     trimmed_order = frames[0].orders.new(frames[0].orders.order_heights - 20)

--- a/banzai_floyds/utils/file_utils.py
+++ b/banzai_floyds/utils/file_utils.py
@@ -1,7 +1,11 @@
 from banzai.utils.file_utils import config_to_filename as banzai_config_to_filename
 
 
-def config_to_filename(image):
+def lampflat_config_to_filename(image) -> str:
     filename = banzai_config_to_filename(image)
     filename = filename.replace('0.1MHz_2.0preamp', '')
     return filename
+
+
+def slit_width_to_filename(image) -> str:
+    return f'{image.slit_width:0.1f}as'

--- a/characterization_testing/FringeFrameMaker.ipynb
+++ b/characterization_testing/FringeFrameMaker.ipynb
@@ -91,7 +91,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "banzai-floyds",
    "language": "python",
    "name": "python3"
   },
@@ -105,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed a bug where all lamp flat stacks would have the same name for a given dayobs irrespective of slitwidth. This led to using whatever the last one to finish being used on _all_ frames irrespective of slit size.